### PR TITLE
fastapi - starlette conflict in dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ email_validator==2.1.1
 exceptiongroup==1.2.0
 factory-boy==3.3.0
 Faker==24.4.0
-fastapi==0.110.0
+fastapi==0.115.5
 greenlet==3.0.3
 gunicorn==22.0.0
 h11==0.14.0


### PR DESCRIPTION
The conflict is caused by:
    The user requested starlette==0.40.0
    fastapi 0.110.0 depends on starlette<0.37.0 and >=0.36.3 Fixes #3 
    
    
    Upgraded fastapi version to accomodate starlette