### PR TITLE
incorrect role assignment during admin email verification

### DIFF
--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -170,7 +170,8 @@ class UserService:
         if user and user.verification_token == token:
             user.email_verified = True
             user.verification_token = None  # Clear the token once used
-            user.role = UserRole.AUTHENTICATED
+            if user.role == UserRole.ANONYMOUS:
+                user.role = UserRole.AUTHENTICATED 
             session.add(user)
             await session.commit()
             return True


### PR DESCRIPTION
In the current verify_email_with_token implementation, all users who verify their email have their role set to AUTHENTICATED, regardless of their original role. This behavior unintentionally overwrites roles like ADMIN or MANAGER, leading to permission downgrades.

Fix #5 
Added a conditional check to ensure that only users with the ANONYMOUS role have their role upgraded to AUTHENTICATED.