### PR TITLE
is_professional field absent in user schema and response

### DIFF
--- a/app/routers/user_routes.py
+++ b/app/routers/user_routes.py
@@ -105,7 +105,8 @@ async def update_user(user_id: UUID, user_update: UserUpdate, request: Request, 
         linkedin_profile_url=updated_user.linkedin_profile_url,
         created_at=updated_user.created_at,
         updated_at=updated_user.updated_at,
-        links=create_user_links(updated_user.id, request)
+        links=create_user_links(updated_user.id, request),
+        is_professional=updated_user.is_professional
     )
 
 

--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -22,6 +22,7 @@ class UserBase(BaseModel):
     nickname: Optional[str] = Field(None, min_length=3, pattern=r'^[\w-]+$', example=generate_nickname())
     first_name: Optional[str] = Field(None, example="John")
     last_name: Optional[str] = Field(None, example="Doe")
+    is_professional: Optional[bool] = Field(default=False, example=True)
     bio: Optional[str] = Field(None, example="Experienced software developer specializing in web applications.")
     profile_picture_url: Optional[str] = Field(None, example="https://example.com/profiles/john.jpg")
     linkedin_profile_url: Optional[str] =Field(None, example="https://linkedin.com/in/johndoe")


### PR DESCRIPTION
Fix: #9 
Add is_professional as an optional field with a default value of False in the UserBase schema in user_schemas.py.
Include is_professional in the user response object in user_routes.py.