### PR TITLE
User Profile Management with Enhanced Profile Update Functionality

### DIFF
--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -38,11 +38,11 @@ def get_current_user(token: str = Depends(oauth2_scheme)):
     payload = decode_token(token)
     if payload is None:
         raise credentials_exception
-    user_id: str = payload.get("sub")
+    user_email: str = payload.get("sub")
     user_role: str = payload.get("role")
-    if user_id is None or user_role is None:
+    if user_email is None or user_role is None:
         raise credentials_exception
-    return {"user_id": user_id, "role": user_role}
+    return {"user_email": user_email, "role": user_role}
 
 def require_role(role: str):
     def role_checker(current_user: dict = Depends(get_current_user)):

--- a/app/routers/user_routes.py
+++ b/app/routers/user_routes.py
@@ -27,7 +27,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies import get_current_user, get_db, get_email_service, require_role
 from app.schemas.pagination_schema import EnhancedPagination
 from app.schemas.token_schema import TokenResponse
-from app.schemas.user_schemas import LoginRequest, UserBase, UserCreate, UserListResponse, UserResponse, UserUpdate
+from app.schemas.user_schemas import LoginRequest, UserBase, UserCreate, UserListResponse, UserResponse, UserUpdate, UserUpdateProfile
 from app.services.user_service import UserService
 from app.services.jwt_service import create_access_token
 from app.utils.link_generation import create_user_links, generate_pagination_links
@@ -246,3 +246,45 @@ async def verify_email(user_id: UUID, token: str, db: AsyncSession = Depends(get
     if await UserService.verify_email_with_token(db, user_id, token):
         return {"message": "Email verified successfully"}
     raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or expired verification token")
+
+# User Profile Management
+@router.put("/update-profile/", response_model=UserResponse, name="update_profile", tags=["User Profile Management"])
+async def update_profile(
+    user_update: UserUpdateProfile,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    token: str = Depends(oauth2_scheme),
+    current_user: dict = Depends(require_role(["ADMIN", "MANAGER", "AUTHENTICATED"]))
+):
+
+    current_user_info = get_current_user(token)
+    user_email = current_user_info['user_email']
+    user = await UserService.get_by_email(db, user_email)
+
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    if user_update.nickname != user.nickname:
+        user_with_existing_nickname = await UserService.get_by_nickname(db, user_update.nickname)
+        if user_with_existing_nickname:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Nickname already exists")
+
+    user_data = user_update.model_dump(exclude_unset=True)
+    updated_user = await UserService.update(db, user.id, user_data)
+
+    return UserResponse.model_construct(
+        is_professional=updated_user.is_professional,
+        id=updated_user.id,
+        bio=updated_user.bio,
+        first_name=updated_user.first_name,
+        last_name=updated_user.last_name,
+        nickname=updated_user.nickname,
+        role=updated_user.role,
+        last_login_at=updated_user.last_login_at,
+        profile_picture_url=updated_user.profile_picture_url,
+        github_profile_url=updated_user.github_profile_url,
+        linkedin_profile_url=updated_user.linkedin_profile_url,
+        created_at=updated_user.created_at,
+        updated_at=updated_user.updated_at,
+        links=create_user_links(updated_user.id, request)
+    )

--- a/app/schemas/user_schemas.py
+++ b/app/schemas/user_schemas.py
@@ -82,3 +82,18 @@ class UserListResponse(BaseModel):
     total: int = Field(..., example=100)
     page: int = Field(..., example=1)
     size: int = Field(..., example=10)
+
+class UserUpdateProfile(BaseModel):
+    nickname: Optional[str] = Field(None, min_length=3, pattern=r'^[\w-]+$', example="john_doe123")
+    first_name: Optional[str] = Field(None, example="John")
+    last_name: Optional[str] = Field(None, example="Doe")
+    bio: Optional[str] = Field(None, example="Experienced software developer specializing in web applications.")
+    profile_picture_url: Optional[str] = Field(None, example="https://example.com/profiles/john.jpg")
+    linkedin_profile_url: Optional[str] =Field(None, example="https://linkedin.com/in/johndoe")
+    github_profile_url: Optional[str] = Field(None, example="https://github.com/johndoe")
+
+    @root_validator(pre=True)
+    def check_at_least_one_value(cls, values):
+        if not any(values.values()):
+            raise ValueError("At least one field must be provided for update")
+        return values

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -238,3 +238,24 @@ def email_service():
         mock_service.send_verification_email.return_value = None
         mock_service.send_user_email.return_value = None
         return mock_service
+
+@pytest.fixture(scope="function")
+async def verified_user_and_token(db_session):
+    user_data = {
+        "email": fake.email(),
+        "nickname": fake.user_name(),
+        "first_name": fake.first_name(),
+        "last_name": fake.last_name(),
+        "hashed_password": hash_password("Secure*1234!"),
+        "role": UserRole.AUTHENTICATED,
+        "email_verified": True,
+        "is_locked": False,
+    }
+    user = User(**user_data)
+    db_session.add(user)
+    await db_session.commit()
+
+    token_data = {"sub": str(user.email), "role": user.role.name}
+    token = create_access_token(data=token_data, expires_delta=timedelta(minutes=30))
+
+    return user, token

--- a/tests/test_api/test_users_api.py
+++ b/tests/test_api/test_users_api.py
@@ -190,3 +190,61 @@ async def test_list_users_unauthorized(async_client, user_token):
         headers={"Authorization": f"Bearer {user_token}"}
     )
     assert response.status_code == 403  # Forbidden, as expected for regular user
+
+@pytest.mark.asyncio
+async def test_update_profile_success(async_client, verified_user_and_token):
+    user, token = verified_user_and_token
+    headers = {"Authorization": f"Bearer {token}"}
+    updated_user_data = {
+        "first_name": "TestUpdate",
+        "last_name": "TestUpdate",
+        "bio": "TestBio",
+        "profile_picture_url": "https://www.example.com/test.jpg",
+        "linkedin_profile_url": "https://www.linkedin.com/test",
+        "github_profile_url": "https://www.github.com/test"
+    }
+    response = await async_client.put("/update-profile/", json=updated_user_data, headers=headers)
+    assert response.status_code == 200
+    response_data = response.json()
+    assert response_data["first_name"] == updated_user_data["first_name"]
+    assert response_data["last_name"] == updated_user_data["last_name"]
+    assert response_data["bio"] == updated_user_data["bio"]
+    assert response_data["profile_picture_url"] == updated_user_data["profile_picture_url"]
+    assert response_data["linkedin_profile_url"] == updated_user_data["linkedin_profile_url"]
+    assert response_data["github_profile_url"] == updated_user_data["github_profile_url"]
+
+@pytest.mark.asyncio
+async def test_update_profile_unauthorized(async_client: AsyncClient):
+    headers = {"Authorization": "Bearer invalid_or_missing_token"}
+
+    response = await async_client.put("/update-profile/", json={"nickname": "newNick"}, headers=headers)
+
+    # Check the response for the expected 401 Unauthorized status
+    assert response.status_code == 401
+    assert "detail" in response.json()
+    assert response.json()["detail"] == "Could not validate credentials"
+
+@pytest.mark.asyncio
+async def test_update_user_profile_duplicate_nickname(async_client, db_session, verified_user_and_token):
+    first_user, token = verified_user_and_token
+    test_user_1 = {
+            "nickname": "TestUser",
+            "first_name": "Test",
+            "last_name": "User",
+            "email": "testuser@example.com",
+            "hashed_password": hash_password("Secure*1234!"),
+            "role": UserRole.AUTHENTICATED,
+            "email_verified": True,
+            "is_locked": False,
+        }
+    first_test_user = User(**test_user_1)
+    db_session.add(first_test_user)
+    await db_session.commit()
+
+    headers = {"Authorization": f"Bearer {token}"}
+    updated_user_data = {
+        "nickname": "TestUser",
+    }
+    response = await async_client.put("/update-profile/", json=updated_user_data, headers=headers)
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Nickname already exists"

--- a/tests/test_schemas/test_user_schemas.py
+++ b/tests/test_schemas/test_user_schemas.py
@@ -2,7 +2,7 @@ import uuid
 import pytest
 from pydantic import ValidationError
 from datetime import datetime
-from app.schemas.user_schemas import UserBase, UserCreate, UserUpdate, UserResponse, UserListResponse, LoginRequest
+from app.schemas.user_schemas import UserBase, UserCreate, UserUpdate, UserResponse, UserListResponse, LoginRequest, UserUpdateProfile
 
 # Fixtures for common test data
 @pytest.fixture
@@ -108,3 +108,28 @@ def test_user_base_url_invalid(url, user_base_data):
     user_base_data["profile_picture_url"] = url
     with pytest.raises(ValidationError):
         UserBase(**user_base_data)
+
+@pytest.fixture
+def single_field_update_data():
+    return {"nickname": "new_nickname"}
+
+@pytest.fixture
+def all_fields_none_update_data():
+    return {
+        "nickname": None,
+        "first_name": None,
+        "last_name": None,
+        "bio": None,
+        "profile_picture_url": None,
+        "linkedin_profile_url": None,
+        "github_profile_url": None
+    }
+
+def test_user_update_profile_valid(single_field_update_data):
+    user_update = UserUpdateProfile(**single_field_update_data)
+    assert user_update.nickname == single_field_update_data["nickname"]
+
+def test_user_update_profile_invalid(all_fields_none_update_data):
+    with pytest.raises(ValidationError) as exc_info:
+        UserUpdateProfile(**all_fields_none_update_data)
+    assert "At least one field must be provided for update" in str(exc_info.value)


### PR DESCRIPTION
Changes: Fixes #11 
1. Dependency Updates (app/dependencies.py)
Updated: get_current_user now fetches user_email instead of user_id.
Rationale: Ensures a clearer, consistent approach by using email as a unique identifier.
2. New API Endpoint in app/routers/user_routes.py
Description: Allows users to update profile fields, such as name, bio, and social media URLs.
Key Behaviors:
Validates all inputs before processing.
Ensures the nickname remains unique.
Updates only fields provided in the request.
Response: Returns updated user details.
3. New Schema in app/schemas/user_schemas.py
Added: UserUpdateProfile schema for profile updates.
Key Additions:
nickname with validation for uniqueness and format.
Fields for first name, last name, bio, profile picture, LinkedIn, and GitHub URLs.
Root-level validator to ensure at least one field is provided during updates.
